### PR TITLE
additional methods for Org, Repo APIs

### DIFF
--- a/lib/github_v3_api/org.rb
+++ b/lib/github_v3_api/org.rb
@@ -20,6 +20,12 @@ class GitHubV3API
       api.list_members(login)
     end
 
+    # Returns an array of GitHubV3API::User instances representing the users
+    # who are public members of the organization
+    def public_members
+      api.list_public_members(login)
+    end
+
     private 
 
     def natural_key

--- a/lib/github_v3_api/org.rb
+++ b/lib/github_v3_api/org.rb
@@ -14,6 +14,12 @@ class GitHubV3API
       api.list_repos(login)
     end
 
+    # Returns an array of GitHubV3API::User instances representing the users
+    # who are members of the organization
+    def members
+      api.list_members(login)
+    end
+
     private 
 
     def natural_key

--- a/lib/github_v3_api/orgs_api.rb
+++ b/lib/github_v3_api/orgs_api.rb
@@ -49,5 +49,15 @@ class GitHubV3API
         GitHubV3API::Repo.new(@connection.repos, repo_data)
       end
     end
+
+    # Returns an array of GitHubV3API::User instances representing the members
+    # who belong to the specified organization.
+    #
+    # +org_login+:: the string ID of the organization, e.g. "github"
+    def list_members(org_login)
+      @connection.get("/orgs/#{org_login}/members").map do |user_data|
+        GitHubV3API::User.new(@connection.users, user_data)
+      end
+    end
   end
 end

--- a/lib/github_v3_api/orgs_api.rb
+++ b/lib/github_v3_api/orgs_api.rb
@@ -59,5 +59,16 @@ class GitHubV3API
         GitHubV3API::User.new(@connection.users, user_data)
       end
     end
+
+    # Returns an array of GitHubV3API::User instances representing the members
+    # who belong to the specified organization who have publicly identified
+    # themselves as members of this organization.
+    #
+    # +org_login+:: the string ID of the organization, e.g. "github"
+    def list_public_members(org_login)
+      @connection.get("/orgs/#{org_login}/public_members").map do |user_data|
+        GitHubV3API::User.new(@connection.users, user_data)
+      end
+    end
   end
 end

--- a/lib/github_v3_api/repo.rb
+++ b/lib/github_v3_api/repo.rb
@@ -11,6 +11,10 @@ class GitHubV3API
       owner['login']
     end
 
+    def collaborators
+      api.list_collaborators(owner_login, name)
+    end
+
     private
 
     def natural_key

--- a/lib/github_v3_api/repo.rb
+++ b/lib/github_v3_api/repo.rb
@@ -15,6 +15,10 @@ class GitHubV3API
       api.list_collaborators(owner_login, name)
     end
 
+    def watchers
+      api.list_watchers(owner_login, name)
+    end
+
     private
 
     def natural_key

--- a/lib/github_v3_api/repo.rb
+++ b/lib/github_v3_api/repo.rb
@@ -19,6 +19,10 @@ class GitHubV3API
       api.list_watchers(owner_login, name)
     end
 
+    def list_forks
+      api.list_forks(owner_login, name)
+    end
+
     private
 
     def natural_key

--- a/lib/github_v3_api/repo.rb
+++ b/lib/github_v3_api/repo.rb
@@ -11,11 +11,11 @@ class GitHubV3API
       owner['login']
     end
 
-    def collaborators
+    def list_collaborators
       api.list_collaborators(owner_login, name)
     end
 
-    def watchers
+    def list_watchers
       api.list_watchers(owner_login, name)
     end
 

--- a/lib/github_v3_api/repos_api.rb
+++ b/lib/github_v3_api/repos_api.rb
@@ -73,7 +73,7 @@ class GitHubV3API
     # +repo_name+:: the string ID of the repository, e.g. "hello-world"
     def list_forks(user, repo_name)
       @connection.get("/repos/#{user}/#{repo_name}/forks").map do |repo_data|
-        GitHubV3API::Repo.new(@connection.repos, repo_data)
+        GitHubV3API::Repo.new(self, repo_data)
       end
     end
 

--- a/lib/github_v3_api/repos_api.rb
+++ b/lib/github_v3_api/repos_api.rb
@@ -43,5 +43,16 @@ class GitHubV3API
     rescue RestClient::ResourceNotFound
       raise NotFound, "The repository #{user}/#{repo_name} does not exist or is not visible to the user."
     end
+
+    # Returns an array of GitHubV3API::User instances for the collaborators of the
+    # specified +user+ and +repo_name+.
+    #
+    # +user+:: the string ID of the user, e.g. "octocat"
+    # +repo_name+:: the string ID of the repository, e.g. "hello-world"
+    def list_collaborators(user, repo_name)
+      @connection.get("/repos/#{user}/#{repo_name}/collaborators").map do |user_data|
+        GitHubV3API::User.new(@connection.users, user_data)
+      end
+    end
   end
 end

--- a/lib/github_v3_api/repos_api.rb
+++ b/lib/github_v3_api/repos_api.rb
@@ -54,5 +54,17 @@ class GitHubV3API
         GitHubV3API::User.new(@connection.users, user_data)
       end
     end
+
+    # Returns an array of GitHubV3API::User instances containing the users who are
+    # watching the repository specified by +user+ and +repo_name+.
+    #
+    # +user+:: the string ID of the user, e.g. "octocat"
+    # +repo_name+:: the string ID of the repository, e.g. "hello-world"
+    def list_watchers(user, repo_name)
+      @connection.get("/repos/#{user}/#{repo_name}/watchers").map do |user_data|
+        GitHubV3API::User.new(@connection.users, user_data)
+      end
+    end
+
   end
 end

--- a/lib/github_v3_api/repos_api.rb
+++ b/lib/github_v3_api/repos_api.rb
@@ -66,5 +66,16 @@ class GitHubV3API
       end
     end
 
+    # Returns an array of GitHubV3API::Repo instances containing the repositories
+    # which were forked from the repository specified by +user+ and +repo_name+.
+    #
+    # +user+:: the string ID of the user, e.g. "octocat"
+    # +repo_name+:: the string ID of the repository, e.g. "hello-world"
+    def list_forks(user, repo_name)
+      @connection.get("/repos/#{user}/#{repo_name}/forks").map do |repo_data|
+        GitHubV3API::Repo.new(@connection.repos, repo_data)
+      end
+    end
+
   end
 end

--- a/spec/org_spec.rb
+++ b/spec/org_spec.rb
@@ -44,4 +44,25 @@ describe GitHubV3API::Org do
       org.repos.should == [:repo1, :repo2]
     end
   end
+
+  describe '#members'do
+    it 'returns an array of User objects who are members of this org' do
+      api = mock(GitHubV3API::OrgsAPI)
+      api.should_receive(:list_members).with('github').and_return([:user1, :user2])
+
+      org = GitHubV3API::Org.new_with_all_data(api, 'login' => 'github')
+      org.members.should == [:user1, :user2]
+    end
+  end
+
+  describe '#public_members'do
+    it 'returns an array of User objects who are public members of this org' do
+      api = mock(GitHubV3API::OrgsAPI)
+      api.should_receive(:list_public_members).with('github').and_return([:user1, :user2])
+
+      org = GitHubV3API::Org.new_with_all_data(api, 'login' => 'github')
+      org.public_members.should == [:user1, :user2]
+    end
+  end
+
 end

--- a/spec/orgs_api_spec.rb
+++ b/spec/orgs_api_spec.rb
@@ -39,4 +39,39 @@ describe GitHubV3API::OrgsAPI do
       api.list_repos('github').should == [:repo1, :repo2]
     end
   end
+
+  describe '#list_members' do
+    it 'returns the list of members for the specified org' do
+      connection = mock(GitHubV3API, :users => :users_api)
+      connection.should_receive(:get).once.with('/orgs/github/members') \
+        .and_return([:user_hash1, :user_hash2])
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash1) \
+        .and_return(:user1)
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash2) \
+        .and_return(:user2)
+
+      api = GitHubV3API::OrgsAPI.new(connection)
+      api.list_members('github').should == [:user1, :user2]
+    end
+  end
+
+  describe '#list_public_members' do
+    it 'returns the list of public members for the specified org' do
+      connection = mock(GitHubV3API, :users => :users_api)
+      connection.should_receive(:get).once.with('/orgs/github/public_members') \
+        .and_return([:user_hash1, :user_hash2])
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash1) \
+        .and_return(:user1)
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash2) \
+        .and_return(:user2)
+
+      api = GitHubV3API::OrgsAPI.new(connection)
+      api.list_public_members('github').should == [:user1, :user2]
+    end
+  end
+
 end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -40,4 +40,41 @@ describe GitHubV3API::Repo do
       repo.owner_login.should == 'octocat'
     end
   end
+
+  describe '#list_collaborators' do
+    it 'returns an array of User objects who are collaborating on this repo' do
+      api = mock(GitHubV3API::ReposAPI)
+      api.should_receive(:list_collaborators).once.with(
+        'octocat', 'hello-world').and_return([:user1, :user2, :user3])
+
+      repo = GitHubV3API::Repo.new(api, 'name' => 'hello-world',
+                                   'owner' => {'login' => 'octocat'})
+      repo.list_collaborators.should == [:user1, :user2, :user3]
+    end
+  end
+
+  describe '#list_watchers' do
+    it 'returns an array of User objects who are watching this repo' do
+      api = mock(GitHubV3API::ReposAPI)
+      api.should_receive(:list_watchers).once.with(
+        'octocat', 'hello-world').and_return([:user1, :user2, :user3])
+
+      repo = GitHubV3API::Repo.new(api, 'name' => 'hello-world',
+                                   'owner' => {'login' => 'octocat'})
+      repo.list_watchers.should == [:user1, :user2, :user3]
+    end
+  end
+
+  describe '#list_forks' do
+    it 'returns an array of Repo objects which were forked from this repo' do
+      api = mock(GitHubV3API::ReposAPI)
+      api.should_receive(:list_forks).once.with(
+        'octocat', 'hello-world').and_return([:repo1, :repo2, :repo3])
+
+      repo = GitHubV3API::Repo.new(api, 'name' => 'hello-world',
+                                   'owner' => {'login' => 'octocat'})
+      repo.list_forks.should == [:repo1, :repo2, :repo3]
+    end
+  end
+
 end

--- a/spec/repos_api_spec.rb
+++ b/spec/repos_api_spec.rb
@@ -30,4 +30,52 @@ describe GitHubV3API::ReposAPI do
       lambda { api.get('octocat', 'hello-world') }.should raise_error(GitHubV3API::NotFound)
     end
   end
+
+  describe "#list_collaborators" do
+    it 'returns a list of Users who are collaborating on the specified repo' do
+      connection = mock(GitHubV3API)
+      connection.should_receive(:get).with(
+        '/repos/octocat/hello-world/collaborators').and_return([:user_hash1, :user_hash2])
+      connection.should_receive(:users).twice.and_return(:users_api)
+      api = GitHubV3API::ReposAPI.new(connection)
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash1).and_return(:user1)
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash2).and_return(:user2)
+
+      collaborators = api.list_collaborators('octocat', 'hello-world')
+      collaborators.should == [:user1, :user2]
+    end
+  end
+
+  describe "#list_watchers" do
+    it 'returns a list of Users who are watching the specified repo' do
+      connection = mock(GitHubV3API)
+      connection.should_receive(:get).with(
+        '/repos/octocat/hello-world/watchers').and_return([:user_hash1, :user_hash2])
+      connection.should_receive(:users).twice.and_return(:users_api)
+      api = GitHubV3API::ReposAPI.new(connection)
+
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash1).and_return(:user1)
+      GitHubV3API::User.should_receive(:new).with(:users_api, :user_hash2).and_return(:user2)
+
+      watchers = api.list_watchers('octocat', 'hello-world')
+      watchers.should == [:user1, :user2]
+    end
+  end
+
+  describe "#list_forks" do
+    it 'returns a list of Repos which were forked from the specified repo' do
+      connection = mock(GitHubV3API)
+      connection.should_receive(:get).with(
+        '/repos/octocat/hello-world/forks').and_return([:repo_hash1, :repo_hash2])
+      api = GitHubV3API::ReposAPI.new(connection)
+
+      GitHubV3API::Repo.should_receive(:new).with(api, :repo_hash1).and_return(:fork1)
+      GitHubV3API::Repo.should_receive(:new).with(api, :repo_hash2).and_return(:fork2)
+
+      forks = api.list_forks('octocat', 'hello-world')
+      forks.should == [:fork1, :fork2]
+    end
+  end
+
 end


### PR DESCRIPTION
# organization API additions
- `orgs.list_public_members(org_name)` -> array of Users who are publicly associated with the organization.
- `org_instance.public_members()` mapping to the above.
- `orgs.list_members(org_name)` -> array of Users who are members of the organization (if user is allowed to see this).
- `org_instance.members()` mapping to the above.
  # repo API
- `repos.list_collaborators(owner, repo_name)` -> Array of Users who are collaborating on this repository.
- `repo_instance.list_collaborators()` mapping to the above.
- `repos.list_watchers(owner, repo_name)` -> Array of Users who are watching this repository.
- `repo_instance.list_watchers()` mapping to the above.
- `repos.list_forks(owner, repo_name)` -> Array of Repositories which were forked from this repository.
- `repo_instance.list_forks()` mapping to the above.
