### PR TITLE
Add 'all' wrapper for '/users' api

### DIFF
--- a/lib/github_v3_api/users_api.rb
+++ b/lib/github_v3_api/users_api.rb
@@ -35,6 +35,12 @@ class GitHubV3API
       user_data = @connection.get("/users/#{username}")
       GitHubV3API::User.new_with_all_data(self, user_data)
     end
-    
+
+    # Returns an array of all GitHubV3API::User instances in the server.
+    def all
+      @connection.get("/users").map do |user_data|
+        GitHubV3API::User.new_with_all_data(self, user_data)
+      end
+    end
   end
 end


### PR DESCRIPTION
This method came in handy reviewing users in my GHE instance (unfortunately, the API doesn't expose whether users are active, dormant, or suspended, but when I combine the list with user data from other sources in my org, I can still get some useful reporting).
